### PR TITLE
Update for Go modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,14 +2,14 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "9.0"
-    working_directory: ~/go/src/github.com/datawire/pf
+      xcode: "9.4.1" # macOS 10.13.3, the oldest version that CircleCI still supports
     steps:
       # Golang install
 
       # For some reason it is faster to curl into a file than to just
-      # pipe the curl straight to tar.
-      - run: curl https://dl.google.com/go/go1.10.2.darwin-amd64.tar.gz -o /tmp/go.tgz
+      # pipe the curl straight to tar.  Note that Go 1.15 requires
+      # macOS 10.12 or newer.
+      - run: curl https://dl.google.com/go/go1.15.5.darwin-amd64.tar.gz -o /tmp/go.tgz
       - run: sudo tar -C /usr/local -xzf /tmp/go.tgz
 
       # Golang paths

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/datawire/pf
+
+go 1.15
+
+require github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/ignore.go
+++ b/ignore.go
@@ -1,0 +1,12 @@
+package pf
+
+// `go mod vendor` will prune unused directories; because there are no
+// .go files in the libkern/ or net/ directories, and because even if
+// there were no other .go file import them, `go mod vendor` won't
+// include them, which is wrong, because we need the .h files in them.
+// So have some "empty" ignore.go files to trick `go mod vendor` in to
+// including the .h files.
+import (
+	_ "github.com/datawire/pf/libkern"
+	_ "github.com/datawire/pf/net"
+)

--- a/libkern/ignore.go
+++ b/libkern/ignore.go
@@ -1,0 +1,1 @@
+package libnet

--- a/net/ignore.go
+++ b/net/ignore.go
@@ -1,0 +1,1 @@
+package net

--- a/rule_direction.go
+++ b/rule_direction.go
@@ -18,8 +18,6 @@ const (
 	DirectionOut Direction = C.PF_OUT
 	// DirectionInOut InOut any direction (ingress/egress) traffic
 	DirectionInOut Direction = C.PF_INOUT
-	// DirectionFwd Forward
-	DirectionFwd Direction = C.PF_FWD
 )
 
 func (d Direction) String() string {
@@ -30,8 +28,6 @@ func (d Direction) String() string {
 		return "out"
 	case DirectionInOut:
 		return "inout"
-	case DirectionFwd:
-		return "fwd"
 	default:
 		return fmt.Sprintf("Direction(%d)", d)
 	}


### PR DESCRIPTION
1. Merge from upstream, just because as long as I'm in this repo it seemed like a good idea
2. Add `go.mod` and `go.sum` files
3. Add some `ignore.go` files to trick `go mod vendor` in to doing the right thing
4. Upgrade CircleCI's macOS, since they've dropped the one we were using.  Also upgrade Go while we're at it